### PR TITLE
Update json2xml.ts

### DIFF
--- a/packages/extension/src/bpmn-adapter/json2xml.ts
+++ b/packages/extension/src/bpmn-adapter/json2xml.ts
@@ -73,7 +73,7 @@ function toXml(obj: string | any[] | Object, name: string, depth: number) {
         attributes +
         (children !== "" ? `>${children}${tn + frontSpace}</${name}>` : " />");
     } else {
-      str += tn + frontSpace + `<$${name}>${obj.toString()}</${name}>`;
+      str += tn + frontSpace + `<${name}>${obj.toString()}</${name}>`;
     }
   }
 


### PR DESCRIPTION
修复导出没有属性和子标签的标签（如bpmn:outgoing）时，标签名称上带有$符号的问题